### PR TITLE
fix(websocket-do): add zod devDependency for example typecheck

### DIFF
--- a/.changeset/chubby-lights-tie.md
+++ b/.changeset/chubby-lights-tie.md
@@ -1,0 +1,5 @@
+---
+"@firtoz/websocket-do": patch
+---
+
+Add `zod` as a dev dependency so `examples/client-usage.ts` typechecks during package CI.

--- a/bun.lock
+++ b/bun.lock
@@ -319,6 +319,7 @@
         "@types/react": "catalog:",
         "bun-types": "catalog:",
         "typescript": "catalog:",
+        "zod": "catalog:",
       },
       "peerDependencies": {
         "@cloudflare/workers-types": "catalog:",

--- a/packages/websocket-do/package.json
+++ b/packages/websocket-do/package.json
@@ -83,6 +83,7 @@
 	"devDependencies": {
 		"@types/react": "catalog:",
 		"bun-types": "catalog:",
-		"typescript": "catalog:"
+		"typescript": "catalog:",
+		"zod": "catalog:"
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`packages/websocket-do/tsconfig.json` includes `examples/**/*`, and `examples/client-usage.ts` imports `zod`, but the package did not declare it. That caused `tsgo --noEmit` to fail with TS2307 in CI.

This change adds `zod` from the workspace catalog as a **devDependency** (examples are not published) and updates the lockfile. A patch changeset is included for `@firtoz/websocket-do`.

**Verification:** `TURBO_TELEMETRY_DISABLED=1 bun turbo run typecheck lint:ci` passes for the full monorepo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-346ec88a-b55a-40a8-ba83-f53909c84aeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-346ec88a-b55a-40a8-ba83-f53909c84aeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

